### PR TITLE
Make loading logo circular on first store visit

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -248,12 +248,12 @@ export default function HomePage() {
             <div className="text-center bg-black/60 backdrop-blur-md rounded-3xl p-8 sm:p-12 max-w-lg mx-auto border border-white/20">
 
               
-              {/* Logo carré = image de fond de la boutique */}
+              {/* Logo rond = image de fond de la boutique */}
               <div className="mb-8">
                 <img 
                   src={settings?.backgroundImage || "https://pub-b38679a01a274648827751df94818418.r2.dev/images/background-oglegacy.jpeg"}
                   alt="LeLoup99" 
-                  className="h-32 sm:h-40 md:h-48 w-32 sm:w-40 md:w-48 mx-auto rounded-xl object-cover border-4 border-white/20"
+                  className="h-32 sm:h-40 md:h-48 w-32 sm:w-40 md:w-48 mx-auto rounded-full object-cover border-4 border-white/20"
                   style={{ filter: 'drop-shadow(0 0 20px rgba(255,255,255,0.3))' }}
                 />
               </div>

--- a/src/app/test-loading/page.tsx
+++ b/src/app/test-loading/page.tsx
@@ -54,7 +54,7 @@ export default function TestLoading() {
                     <img 
                       src={settings.backgroundImage} 
                       alt="LeLoup99" 
-                      className="w-32 h-32 object-contain rounded-lg animate-pulse"
+                      className="w-32 h-32 object-contain rounded-full animate-pulse"
                       style={{ filter: 'drop-shadow(0 0 20px rgba(255,255,255,0.3))' }}
                     />
                   ) : (


### PR DESCRIPTION
Make the loading logo round instead of square.

---
<a href="https://cursor.com/background-agent?bcId=bc-520b7d01-448e-4273-8df3-36bd0675bd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-520b7d01-448e-4273-8df3-36bd0675bd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

